### PR TITLE
fix 'cd falsepages' command issue

### DIFF
--- a/package/lighthouse/lighthouse.js
+++ b/package/lighthouse/lighthouse.js
@@ -56,7 +56,7 @@ async function startServer() {
 
 // Traverse the 'pages' folder in project directory and capture list of endpoints to check
 function getRoutes(subfolders = '') {
-  let commands = `cd ${SRC_DIRECTORY && `src/`}pages`;
+  let commands = `cd ${SRC_DIRECTORY ? `src/` : ''}pages`;
   if (subfolders !== '') commands += ` && cd ${subfolders}`;
   try {
     const stdOut = execSync(`${commands} && ls`, { encoding: 'utf-8' });


### PR DESCRIPTION
#91 introduced a bug if `nextAppSettings.srcDirectory === false` (default)

This results in the `command` being evaluated as `cd falsepages` (instead of the expected `cd pages`).

The fix is simple, use a ternary instead of conditional chaining.

This bug appears to affect `vantage-next` at `v1.0.4` and `v1.0.5`.